### PR TITLE
Add email validation for CH only emails

### DIFF
--- a/src/controllers/loginController.ts
+++ b/src/controllers/loginController.ts
@@ -51,7 +51,11 @@ export const registerPost = async (req: Request, res: Response, next: NextFuncti
     } catch (error) {
         if (error.response && error.response.status === 400) {
             return res.render('register', { error: 'Error Creating Account', RETURN_URL: `${returnTo}` });
+        } else if(error.message) {
+            return res.render('register', { error: `${error.message}`, RETURN_URL: `${returnTo}`})
+        } else {
+            return next(error);
         }
-        return next(error);
+
     }
 };

--- a/src/controllers/loginController.ts
+++ b/src/controllers/loginController.ts
@@ -52,7 +52,7 @@ export const registerPost = async (req: Request, res: Response, next: NextFuncti
         if (error.response && error.response.status === 400) {
             return res.render('register', { error: 'Error Creating Account', RETURN_URL: `${returnTo}` });
         } else if(error.message) {
-            return res.render('register', { error: `${error.message}`, RETURN_URL: `${returnTo}`})
+            return res.render('register', { error: `${error.message}`, RETURN_URL: `${returnTo}`});
         } else {
             return next(error);
         }

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -9,6 +9,12 @@ import { CMS_API_URL, MOCK_API_RESPONSES } from '../properties';
 
 export const register = async (res: Response, username: string, email: string, password: string): Promise<void> => {
   
+  const emailValidationRegExp = /^\w+@companieshouse.gov.uk$/; // regExp literal
+  
+  // Check if the email is NOT a companies house email and throw an error if it isn't
+  if(!email.match(emailValidationRegExp)) {
+      throw new Error("Email address is not a Companies House provided email.");
+  }
   const url: string = CMS_API_URL + '/auth/local/register';
 
   const axiosConfig: axios.AxiosRequestConfig = getBaseAxiosRequestConfig(


### PR DESCRIPTION
Uses a regular expression of ^\w+@companieshouse.gov.uk$ which matches any number of word characters (alphanumeric) at the start of the string with `@companieshouse.gov.uk` at the end of the string.

Usage:
test@notcompanieshouse.com // no match, disallows account registering
amyatt1@companieshouse.gov.uk // match, allows account registering

This is so only CH provided email accounts can be registered to the service.

The service will still need user verification on account creation, which will require sending the user a confirmation email before their account becomes verified and allows them to log in.