### PR TITLE
Add target to links to open in new tab

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -4,3 +4,4 @@ A more comprehensive set of documentation can be found in each subfolder.
 ## List of Documentation
 - [Routing](routing/routing.md)
 - [Authentication](authentication/authentication.md)
+- [Markdown](markdown/markdown.md)

--- a/docs/markdown/markdown.md
+++ b/docs/markdown/markdown.md
@@ -1,0 +1,2 @@
+# Markdown to HTML Conversion
+The webapp retrieves content from the STRAPI backend in Markdown format. This is converted to HTML through the [markedjs](https://github.com/markedjs/marked/blob/master/src/Renderer.js) library. HTML attributes that are converted using markedjs can be expanded upon using a renderer. All relevant code is contained in the [markdownHtmlConverterService.ts](../../src/services/markdownHtmlConverterService.ts).

--- a/src/services/markdownHtmlConverterService.ts
+++ b/src/services/markdownHtmlConverterService.ts
@@ -33,7 +33,7 @@ function sanitiseOptions(): IOptions {
           ],
           disallowedTagsMode: 'discard',
           allowedAttributes: {
-            a: [ 'href', 'name', 'target' ],
+            a: [ 'href', 'name', 'rel', 'target' ],
             img: [ 'src', "alt" ],
             iframe: [ 'class', 'width', 'height', 'src', 'title', 'frameborder', 'allow', 'allowfullscreen'],
             p: ['class'],
@@ -48,7 +48,10 @@ function sanitiseOptions(): IOptions {
     };
 }
 
-// Override Marked functions to add gov uk classes to elements we want
+/*
+  Override Marked functions to add gov uk classes to elements we want
+  Add the target="_blank" option to links so they open in new tabs
+*/
 const renderer = {
     list(body: string, ordered: boolean, start: string | number) {
         const type = ordered ? 'ol' : 'ul',
@@ -58,6 +61,17 @@ const renderer = {
       },
       paragraph(text: string) {
         return '<p class="govuk-body">' + text + '</p>\n';
+      },
+      link(href: string, title: string, text: string) {
+        if (href === null) {
+          return text;
+        }
+        let out = '<a href="' + href + '"';
+        if (title) {
+          out += ' title="' + title + '"';
+        }
+        out += ' target="_blank" rel="noopener noreferrer">' + text + '</a>';
+        return out;
       }
 };
 


### PR DESCRIPTION
Users of the service would like links to open in a new tab so they do not lose their current page that they are reading from.
Example use of HTML to open link in new tab:
`<a href="https://www.somewebsite.com" target="_blank" rel="noopener noreferrer">the somewebsite webpage</a>`

Add target="_blank" to open links in new tabs
Add rel="noopener noreferrer" to prevent tabnabbing
Add markdown documentation

Resolves DOP-575