### PR TITLE
Make name and email field clearer on register screen

### DIFF
--- a/views/register.html
+++ b/views/register.html
@@ -25,18 +25,18 @@
             <div class="govuk-form-group">
               <h1 class="govuk-label-wrapper">
                 <label class="govuk-label" for="email">
-                  Email
+                  Companies House Email Address
                 </label>
               </h1>
-              <input class="govuk-input" id="email" name="email" type="email" placeholder="Companies House email address">
+              <input class="govuk-input" id="email" name="email" type="email">
             </div>
             <div class="govuk-form-group">
               <h1 class="govuk-label-wrapper">
                 <label class="govuk-label" for="username">
-                  Name
+                  Full Name
                 </label>
               </h1>
-              <input class="govuk-input" id="username" name="username" type="text" placeholder="First name and last name">
+              <input class="govuk-input" id="username" name="username" type="text">
             </div>
             <div class="govuk-form-group">
               <h1 class="govuk-label-wrapper">

--- a/views/register.html
+++ b/views/register.html
@@ -28,7 +28,7 @@
                   Email
                 </label>
               </h1>
-              <input class="govuk-input" id="email" name="email" type="email">
+              <input class="govuk-input" id="email" name="email" type="email" placeholder="Companies House email address">
             </div>
             <div class="govuk-form-group">
               <h1 class="govuk-label-wrapper">
@@ -36,7 +36,7 @@
                   Name
                 </label>
               </h1>
-              <input class="govuk-input" id="username" name="username" type="text">
+              <input class="govuk-input" id="username" name="username" type="text" placeholder="First name and last name">
             </div>
             <div class="govuk-form-group">
               <h1 class="govuk-label-wrapper">


### PR DESCRIPTION
Add placeholder text to input fields so that required values are
presently more clearly to the user while registering

[DOP-570](https://companieshouse.atlassian.net/browse/DOP-570)